### PR TITLE
AEROGEAR-1964: Setup testing framework for the IntelliJ plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/*
 build/*
 out/*
 *.zip
+lib/*

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ It's very easy to set it up as an IntelliJ project.
 
 Once ```build.gradle``` gets updated, you need to "Refresh all Gradle projects" in the Gradle panel.
 
+Run the plugin tests
+1. Ensure that the ```Gradle``` plugin is enabled and properly configured in IntelliJ as detailed above.
+2. Open the ```Gradle``` panel and run the task ```test``` under "Tasks" -> "Verification" -> "test"
 
 Contributing
 ------------

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,18 @@ configurations {
 dependencies {
     ideaSdk fileTree(dir: 'lib/sdk/', include: ['*/lib/*.jar'])
     testCompile group: 'junit', name: 'junit', version: '4.12'
+
+    testCompile 'org.testng:testng:6.8.21'
+}
+
+sourceSets {
+
+    // Set test source
+    test {
+        java {
+            java.srcDir 'src/test/java'
+        }
+    }
 }
 
 def IDEA_SDK_URL = 'https://download-cf.jetbrains.com/idea/ideaIC-2017.3.3.tar.gz'
@@ -30,6 +42,8 @@ def IDEA_SDK_NAME = 'IntelliJ IDEA Community Edition IC-173.4301.25'
 test {
     // Avoid parallel execution, since the IntelliJ boilerplate is not up to that
     maxParallelForks = 1
+
+    useTestNG()
 }
 
 task downloadIdeaSdk(type: Download) {

--- a/src/test/java/org/aerogear/plugin/intellij/mobile/api/MobileAPITest.java
+++ b/src/test/java/org/aerogear/plugin/intellij/mobile/api/MobileAPITest.java
@@ -1,0 +1,13 @@
+package org.aerogear.plugin.intellij.mobile.api;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class MobileAPITest {
+    @Test
+    public void testGetServices() {
+        System.out.println("Get Services Test");
+        Assert.assertEquals(0, 0);
+    }
+
+}

--- a/src/test/java/org/aerogear/plugin/intellij/mobile/api/MobileAPITest.java
+++ b/src/test/java/org/aerogear/plugin/intellij/mobile/api/MobileAPITest.java
@@ -1,13 +1,14 @@
 package org.aerogear.plugin.intellij.mobile.api;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.testng.annotations.*;
 
 public class MobileAPITest {
+    @BeforeClass
+    public void setup() {
+    }
+
     @Test
     public void testGetServices() {
-        System.out.println("Get Services Test");
-        Assert.assertEquals(0, 0);
     }
 
 }


### PR DESCRIPTION
## Description
We need to setup TestNG in order to write tests for the IntelliJ plugin. This needs to be configured to work with gradle. 

## Task
- [x] Setup TestNG with Gradle

## Related Notes
Related JIRA Ticket - https://issues.jboss.org/browse/AEROGEAR-1964
[TestNG](http://testng.org/doc/)
[Sample Gradle project with TestNG](https://github.com/dev9com/gradle-example)