### PR TITLE
Android Studio support, intellij block

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,19 @@ compileJava.dependsOn extractIdeaSdk
 
 apply plugin: 'idea'
 
+intellij {
+  updateSinceUntilBuild false
+  version '172.4343.14'
+  plugins = ['properties', 'Groovy', 'gradle', 'android']
+// UnComment one of the following lines and set your path to Android Studio.
+// Example for linux
+//    alternativeIdePath = '/home/$USER/Programs/android-studio'
+// Example for Mac
+//    alternativeIdePath = '/Applications/Android Studio.app'
+
+
+}
+
 idea {
     project {
         languageLevel = '1.8'


### PR DESCRIPTION
# WHAT
Android Studio Support 

# How to test 
 * Install Android Studio
 * Uncomment build.gradle#80 and set the value to the path to your Android Studio install
 * Run the plugin with `./gradlew runIde`

# What you should see
Android Studio should start up and you should have AeroGear Mobile in the side panel

# Future Work
The IntelliJ gradle plugin can probably do a lot of the things that the download tasks are doing right now.  In the future it may be good to cleanup the gradle file to make it simpler by putting more things into the plugin's configuration.