### PR TITLE
Plugin settings and SDK config path storing

### DIFF
--- a/src/main/java/org/aerogear/plugin/intellij/mobile/ui/settings/AeroGearMobileConfigurable.java
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/ui/settings/AeroGearMobileConfigurable.java
@@ -1,0 +1,58 @@
+package org.aerogear.plugin.intellij.mobile.ui.settings;
+
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
+import com.intellij.openapi.options.Configurable;
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.TextBrowseFolderListener;
+import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class AeroGearMobileConfigurable implements Configurable {
+
+    private AeroGearMobileConfiguration config;
+    private Project project;
+    private TextFieldWithBrowseButton configPathValue;
+
+    public AeroGearMobileConfigurable(Project project) {
+        this.project = project;
+        this.config = AeroGearMobileConfiguration.getInstance(project);
+    }
+
+    @Nls
+    @Override
+    public String getDisplayName() {
+        return "AeroGear Mobile";
+    }
+
+    @Nullable
+    @Override
+    public JComponent createComponent() {
+        SettingsPanel settingsPanel = new SettingsPanel();
+        this.configPathValue = settingsPanel.getSdkConfigValue();
+        this.configPathValue.addBrowseFolderListener(new TextBrowseFolderListener(FileChooserDescriptorFactory.createSingleFileDescriptor(), project));
+        return settingsPanel;
+    }
+
+    @Override
+    public boolean isModified() {
+        String configPath = this.config.getConfigPath();
+        return configPath != null && !configPath.equals(this.configPathValue.getText());
+    }
+
+    @Override
+    public void apply() throws ConfigurationException {
+        this.config.setConfigPath(this.configPathValue.getText());
+    }
+
+    @Override
+    public void reset() {
+        String configPath = this.config.getConfigPath();
+        if (configPath != null) {
+            this.configPathValue.setText(configPath);
+        }
+    }
+}

--- a/src/main/java/org/aerogear/plugin/intellij/mobile/ui/settings/AeroGearMobileConfiguration.java
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/ui/settings/AeroGearMobileConfiguration.java
@@ -1,0 +1,48 @@
+package org.aerogear.plugin.intellij.mobile.ui.settings;
+
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.xmlb.XmlSerializerUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * PersistentStateComponent keeps project config values.
+ */
+@State(
+        name="AeroGearMobileConfiguration",
+        storages = {
+                @Storage("AeroGearMobileConfiguration.xml")
+        }
+)
+
+public class AeroGearMobileConfiguration implements PersistentStateComponent<AeroGearMobileConfiguration> {
+    private String configPath;
+
+    @Nullable
+    @Override
+    public AeroGearMobileConfiguration getState() {
+        return this;
+    }
+
+    @Override
+    public void loadState(@NotNull AeroGearMobileConfiguration state) {
+        XmlSerializerUtil.copyBean(state, this);
+    }
+
+    @Nullable
+    public static AeroGearMobileConfiguration getInstance(Project project) {
+        return ServiceManager.getService(project, AeroGearMobileConfiguration.class);
+    }
+
+    public String getConfigPath() {
+        return configPath;
+    }
+
+    public void setConfigPath(String configPath) {
+        this.configPath = configPath;
+    }
+}

--- a/src/main/java/org/aerogear/plugin/intellij/mobile/ui/settings/SettingsPanel.form
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/ui/settings/SettingsPanel.form
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<Form version="1.8" maxVersion="1.9" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
+  <AuxValues>
+    <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="0"/>
+    <AuxValue name="FormSettings_autoSetComponentName" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_generateFQN" type="java.lang.Boolean" value="true"/>
+    <AuxValue name="FormSettings_generateMnemonicsCode" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_i18nAutoMode" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_layoutCodeTarget" type="java.lang.Integer" value="1"/>
+    <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
+    <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
+  </AuxValues>
+
+  <Layout>
+    <DimensionLayout dim="0">
+      <Group type="103" groupAlignment="0" attributes="0">
+          <Component id="projectSettingsHeader" alignment="0" max="32767" attributes="0"/>
+          <Component id="projectSettings" alignment="0" max="32767" attributes="0"/>
+      </Group>
+    </DimensionLayout>
+    <DimensionLayout dim="1">
+      <Group type="103" groupAlignment="0" attributes="0">
+          <Group type="102" attributes="0">
+              <Component id="projectSettingsHeader" min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+              <Component id="projectSettings" max="32767" attributes="0"/>
+          </Group>
+      </Group>
+    </DimensionLayout>
+  </Layout>
+  <SubComponents>
+    <Container class="javax.swing.JPanel" name="projectSettingsHeader">
+
+      <Layout>
+        <DimensionLayout dim="0">
+          <Group type="103" groupAlignment="0" attributes="0">
+              <Group type="102" alignment="0" attributes="0">
+                  <EmptySpace max="-2" attributes="0"/>
+                  <Component id="headerText" min="-2" max="-2" attributes="0"/>
+                  <EmptySpace max="-2" attributes="0"/>
+                  <Component id="headerSeparator" max="32767" attributes="0"/>
+                  <EmptySpace max="-2" attributes="0"/>
+              </Group>
+          </Group>
+        </DimensionLayout>
+        <DimensionLayout dim="1">
+          <Group type="103" groupAlignment="1" attributes="0">
+              <Component id="headerText" min="-2" max="-2" attributes="0"/>
+              <Component id="headerSeparator" min="-2" pref="10" max="-2" attributes="0"/>
+          </Group>
+        </DimensionLayout>
+      </Layout>
+      <SubComponents>
+        <Component class="javax.swing.JLabel" name="headerText">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Project settings"/>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JSeparator" name="headerSeparator">
+        </Component>
+      </SubComponents>
+    </Container>
+    <Container class="javax.swing.JPanel" name="projectSettings">
+
+      <Layout>
+        <DimensionLayout dim="0">
+          <Group type="103" groupAlignment="0" attributes="0">
+              <Group type="102" alignment="0" attributes="0">
+                  <EmptySpace max="-2" attributes="0"/>
+                  <Component id="sdkConfigLabel" min="-2" max="-2" attributes="0"/>
+                  <EmptySpace max="-2" attributes="0"/>
+                  <Component id="sdkConfigValue" min="-2" max="-2" attributes="0"/>
+                  <EmptySpace pref="497" max="32767" attributes="0"/>
+              </Group>
+          </Group>
+        </DimensionLayout>
+        <DimensionLayout dim="1">
+          <Group type="103" groupAlignment="0" attributes="0">
+              <Group type="102" alignment="1" attributes="0">
+                  <EmptySpace pref="16" max="32767" attributes="0"/>
+                  <Group type="103" groupAlignment="3" attributes="0">
+                      <Component id="sdkConfigLabel" alignment="3" min="-2" max="-2" attributes="0"/>
+                      <Component id="sdkConfigValue" alignment="3" min="-2" max="-2" attributes="0"/>
+                  </Group>
+                  <EmptySpace max="-2" attributes="0"/>
+              </Group>
+          </Group>
+        </DimensionLayout>
+      </Layout>
+      <SubComponents>
+        <Component class="javax.swing.JLabel" name="sdkConfigLabel">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="SDK config path"/>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JTextField" name="sdkConfigValue">
+          <Events>
+            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="sdkConfigValueActionPerformed"/>
+          </Events>
+        </Component>
+      </SubComponents>
+    </Container>
+  </SubComponents>
+</Form>

--- a/src/main/java/org/aerogear/plugin/intellij/mobile/ui/settings/SettingsPanel.java
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/ui/settings/SettingsPanel.java
@@ -1,0 +1,98 @@
+package org.aerogear.plugin.intellij.mobile.ui.settings;
+
+
+import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+
+
+public class SettingsPanel extends javax.swing.JPanel {
+
+    public SettingsPanel() {
+        initComponents();
+    }
+
+    private void initComponents() {
+
+
+        projectSettingsHeader = new javax.swing.JPanel();
+        headerText = new javax.swing.JLabel();
+        headerSeparator = new javax.swing.JSeparator();
+        projectSettings = new javax.swing.JPanel();
+        sdkConfigLabel = new javax.swing.JLabel();
+        sdkConfigValue = new TextFieldWithBrowseButton();
+
+        headerText.setText("Project settings");
+
+        javax.swing.GroupLayout projectSettingsHeaderLayout = new javax.swing.GroupLayout(projectSettingsHeader);
+        projectSettingsHeader.setLayout(projectSettingsHeaderLayout);
+        projectSettingsHeaderLayout.setHorizontalGroup(
+                projectSettingsHeaderLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                        .addGroup(projectSettingsHeaderLayout.createSequentialGroup()
+                                .addContainerGap()
+                                .addComponent(headerText)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(headerSeparator)
+                                .addContainerGap())
+        );
+        projectSettingsHeaderLayout.setVerticalGroup(
+                projectSettingsHeaderLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
+                        .addComponent(headerText)
+                        .addComponent(headerSeparator, javax.swing.GroupLayout.PREFERRED_SIZE, 10, javax.swing.GroupLayout.PREFERRED_SIZE)
+        );
+
+        javax.swing.GroupLayout projectSettingsLayout = new javax.swing.GroupLayout(projectSettings);
+        projectSettings.setLayout(projectSettingsLayout);
+        projectSettingsLayout.setHorizontalGroup(
+                projectSettingsLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                        .addGroup(projectSettingsLayout.createSequentialGroup()
+                                .addContainerGap()
+                                .addComponent(sdkConfigValue, javax.swing.GroupLayout.DEFAULT_SIZE, 478, Short.MAX_VALUE)
+                                .addContainerGap())
+        );
+        projectSettingsLayout.setVerticalGroup(
+                projectSettingsLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                        .addGroup(projectSettingsLayout.createSequentialGroup()
+                                .addGap(24, 24, 24)
+                                .addComponent(sdkConfigValue, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addContainerGap(28, Short.MAX_VALUE))
+        );
+
+        sdkConfigLabel.setText("SDK config path");
+
+        javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
+        this.setLayout(layout);
+        layout.setHorizontalGroup(
+                layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                        .addComponent(projectSettingsHeader, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addGroup(layout.createSequentialGroup()
+                                .addGap(40, 40, 40)
+                                .addComponent(sdkConfigLabel)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(projectSettings, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+        );
+        layout.setVerticalGroup(
+                layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                        .addGroup(layout.createSequentialGroup()
+                                .addComponent(projectSettingsHeader, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                                        .addGroup(layout.createSequentialGroup()
+                                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                                .addComponent(projectSettings, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                                        .addGroup(layout.createSequentialGroup()
+                                                .addGap(36, 36, 36)
+                                                .addComponent(sdkConfigLabel)
+                                                .addGap(0, 0, Short.MAX_VALUE))))
+        );
+    }// </editor-fold>
+
+    private javax.swing.JSeparator headerSeparator;
+    private javax.swing.JLabel headerText;
+    private javax.swing.JPanel projectSettings;
+    private javax.swing.JPanel projectSettingsHeader;
+    private javax.swing.JLabel sdkConfigLabel;
+    private TextFieldWithBrowseButton sdkConfigValue;
+
+    public TextFieldWithBrowseButton getSdkConfigValue() {
+        return sdkConfigValue;
+    }
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -29,6 +29,8 @@
         <toolWindow id="Aerogear Mobile" secondary="true" anchor="right"
                     factoryClass="org.aerogear.plugin.intellij.mobile.ui.MobileToolWindowFactory"/>
         <applicationService serviceImplementation="org.aerogear.plugin.intellij.mobile.services.MobileNotificationsService" />
+        <projectConfigurable groupId="tools" displayName="AeroGearMobileConfigurable" id="aerogear.mobile.configurable" instance="org.aerogear.plugin.intellij.mobile.ui.settings.AeroGearMobileConfigurable" />
+        <projectService serviceInterface="org.aerogear.plugin.intellij.mobile.ui.settings.AeroGearMobileConfiguration" serviceImplementation="org.aerogear.plugin.intellij.mobile.ui.settings.AeroGearMobileConfiguration"/>
     </extensions>
 
     <actions>


### PR DESCRIPTION
## Description
An option should be available to specify the file location to place the generated config. 
This PR adds the initial base for our plugin settings.

A few notes on the Settings API.
- We must declare a class that extends `Configurable` (`AeroGearMobileConfigurable`) which returns our settings component and reacts to saving/resetting/isModified events.
- Storage is managed by `AeroGearMobileConfiguration` which implements `PersistentStateComponent` and the `storage` annotation. Any properties on `AeroGearMobileConfiguration` will be saved (serialized to xml) on IDE exit in a file called `AeroGearMobileConfiguration.xml`. Reloaded again on IDE startup.

## Additional Notes
JIRA Ticket - https://issues.jboss.org/browse/AEROGEAR-1919

![settings-config](https://user-images.githubusercontent.com/22113654/35696821-6429899a-0780-11e8-9740-9bb966921be7.png)
