### PR TITLE
AEROGEAR-2080 Create development releases automation of the IntelliJ plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,14 @@
 plugins {
     id 'org.jetbrains.intellij' version '0.2.17'
+    id "com.github.breadmoirai.github-release" version "1.1.3"
+    id "net.researchgate.release" version "2.4.0"
 }
 
 group 'org.aerogear'
-version '1.0-SNAPSHOT'
 
 apply plugin: 'java'
+apply from: "gradle/autovers.gradle"
+apply from: "gradle/download.gradle"
 
 sourceCompatibility = 1.8
 
@@ -18,7 +21,6 @@ configurations {
     ideaSdk
     bundle // dependencies bundled with the plugin
 }
-
 
 dependencies {
     ideaSdk fileTree(dir: 'lib/sdk/', include: ['*/lib/*.jar'])
@@ -48,7 +50,7 @@ test {
     useTestNG()
 }
 
-task downloadIdeaSdk(type: Download) {
+downloadIdeaSdk {
     sourceUrl = IDEA_SDK_URL
     target = file('lib/idea-sdk.tar.gz')
 }
@@ -109,7 +111,7 @@ idea {
     }
 
     module {
-        scopes.COMPILE.minus = [ configurations.ideaSdk ]
+        scopes.COMPILE.minus = [configurations.ideaSdk]
 
         iml {
             beforeMerged { module ->
@@ -126,25 +128,49 @@ idea {
     }
 }
 
+release {
+    failOnCommitNeeded = false
+    failOnPublishNeeded = false
+    failOnSnapshotDependencies = false
+    failOnUnversionedFiles = false
+    failOnUpdateNeeded = false
+    revertOnFail = false
+    preTagCommitMessage = '[AG Mobile Release] - pre tag commit: '
+    tagCommitMessage = '[AG Mobile Release] - creating tag: '
+    newVersionCommitMessage = '[AG Mobile Release] - new version commit: '
+    tagTemplate = 'v${version}'
+    buildTasks = ['buildPlugin']
+
+    scmAdapters = [
+            net.researchgate.release.GitAdapter
+    ]
+
+    git {
+        requireBranch = /t_release_automation/ // TODO change it to master branch
+        pushToRemote = 'origin'
+        pushToBranchPrefix = ''
+        commitVersionFileOnly = false
+    }
+}
+updateVersion.dependsOn tasks.githubRelease
+
+githubRelease {
+    targetCommitish = /t_release_automation/ // TODO change it to master branch
+    name = "Aerogear Mobile Intellij Plugin v${project['release.releaseVersion']}"
+    token = "$System.env.GITHUB_TOKEN" // required
+    body = "Wham, bam! Thank you for new release!" // TODO, create task to generate CHANGELOG
+    draft = false
+    prerelease = true
+    FilenameFilter filter = { dir, file -> file.contains("${project['release.releaseVersion']}") }
+    releaseAssets = { -> buildPlugin.archivePath.parentFile.listFiles filter }
+}
+// TODO Create task Add CHANGELOG to plugin.xml file
+
 task wrapper(type: Wrapper) {
     gradleVersion = '4.1'
 }
 
-// ========= Custom tasks ========= //
-
-class Download extends DefaultTask {
-    @Input
-    String sourceUrl
-
-    @OutputFile
-    File target
-
-    @TaskAction
-    void download() {
-        if (!target.parentFile.exists()) {
-           target.parentFile.mkdirs()
-        }
-        logger.lifecycle "Downloading ${sourceUrl}, this might take a minute..."
-        ant.get(src: sourceUrl, dest: target, skipexisting: 'true')
-    }
+processResources {
+    inputs.property "version", project.version
+    filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: [version: project.version])
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.0.1
+version=0.0.2-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.0.2
+version=0.0.3-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.0.2-SNAPSHOT
+version=0.0.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+version=0.0.1-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.0.1-SNAPSHOT
+version=0.0.1

--- a/gradle/autovers.gradle
+++ b/gradle/autovers.gradle
@@ -1,0 +1,51 @@
+ext.semanticVersion = SemanticVersion.from(version)
+project.ext['release.useAutomaticVersion'] = 'true'
+project.ext['release.releaseVersion'] = semanticVersion.releaseVersion()
+project.ext['release.newVersion'] = semanticVersion.newVersion()
+
+class SemanticVersion {
+    int major
+    int minor
+    int patch
+    String extension
+
+    SemanticVersion newVersion(String releaseType = "patch") {
+        def instance
+        switch (releaseType) {
+            case ~/^major$/:
+                instance = new SemanticVersion(major: major + 1, minor: 0, patch: 0, extension: "SNAPSHOT")
+                break;
+            case ~/^minor$/:
+                instance = new SemanticVersion(major: major, minor: minor + 1, patch: 0, extension: "SNAPSHOT")
+                break
+            case ~/^patch$/:
+                instance = new SemanticVersion(major: major, minor: minor, patch: patch + 1, extension: "SNAPSHOT")
+                break
+            default:
+                throw new GradleException("Cannot release version '${project.version.toString()}' with wrong '${releaseType}'!")
+        }
+        return instance
+    }
+
+    static SemanticVersion from(String versionString) {
+        def splitted = versionString.split('[\\.-]')
+        return new SemanticVersion(
+                major: Integer.parseInt(splitted[0]),
+                minor: Integer.parseInt(splitted[1]),
+                patch: Integer.parseInt(splitted[2]),
+                extension: splitted.length != 4 ?: splitted[3]
+        )
+    }
+
+    SemanticVersion releaseVersion() {
+        if (extension == null) {
+            return this
+        } else {
+            return new SemanticVersion(major: major, minor: minor, patch: patch, extension: null)
+        }
+    }
+
+    String toString() {
+        "${major}.${minor}.${patch}${extension ? '-' + extension.toString() : ''}"
+    }
+}

--- a/gradle/download.gradle
+++ b/gradle/download.gradle
@@ -1,0 +1,17 @@
+task downloadIdeaSdk(type: Download)
+class Download extends DefaultTask {
+    @Input
+    String sourceUrl
+
+    @OutputFile
+    File target
+
+    @TaskAction
+    void download() {
+        if (!target.parentFile.exists()) {
+            target.parentFile.mkdirs()
+        }
+        logger.lifecycle "Downloading ${sourceUrl}, this might take a minute..."
+        ant.get(src: sourceUrl, dest: target, skipexisting: 'true')
+    }
+}


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
[AEROGEAR-2080](https://issues.jboss.org/browse/AEROGEAR-2080)

**Changes proposed in this pull request**
Added semantic version check and autoreleasing
Added gradle.properties with plugin version
Added download.gradle script for downloading files
Added autovers gradle script for automatic version generation
Added github release plugin for pushing artifacts to github repo

**To run release automation you need run gradle task**: `gradle release`
It automatically create release and push it to github
Updates version to be new one with SNAPSHOT
Pushes new tags and changes to github

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes AEROGEAR-2080