### PR TITLE
Changing slave to maven because the embedded configuration was acting up

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,23 +1,15 @@
-def goIdeaGradle = containerTemplate(
-  name: 'jnlp', 
-  image: 'docker.io/openshift/jenkins-slave-maven-centos7:latest',
-  args: '${computer.jnlpmac} ${computer.name}',
-  ttyEnabled: false) 
-
-podTemplate(label: 'idea-gradle', cloud: "openshift", containers: [goIdeaGradle]) {
-  node ("idea-gradle") {
-    stage("Checkout") {
-      checkout scm
-    }
-    
-    stage ("Setup") {
-      sh "./gradlew extractIdeaSdk"
-    }
-    
-    stage ("Build") {
-      sh "./gradlew dist"
-      archiveArtifacts artifacts: 'build/distributions/*', onlyIfSuccessful: true
-    }
+node ("maven") {
+  stage("Checkout") {
+    checkout scm
+  }
+  
+  stage ("Setup") {
+    sh "./gradlew extractIdeaSdk"
+  }
+  
+  stage ("Build") {
+    sh "./gradlew dist"
+    archiveArtifacts artifacts: 'build/distributions/*', onlyIfSuccessful: true
   }
 }
 


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
For some reason, the current setup attemps to schedule ungodly ammount of pods and everyone keeps failing.

Changing back to "maven" label fixes things.
