### PR TITLE
Pre populate appId from project config

### DIFF
--- a/src/main/java/org/aerogear/plugin/intellij/mobile/services/configuration/AndroidManifest.java
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/services/configuration/AndroidManifest.java
@@ -11,7 +11,7 @@ public class AndroidManifest extends ConfigurationXml{
 
     public String getPackage(Project project) {
         String packageName = "";
-        String manifestPath = project.getBasePath() + File.separator + "src" + File.separator + "main" + File.separator + "AndroidManifest.xml";
+        String manifestPath = project.getBasePath() + File.separator + "app" + File.separator + "src" + File.separator + "main" + File.separator + "AndroidManifest.xml";
         XmlTag manifest = this.getRootTag(project, manifestPath);
         if (manifest != null) {
             packageName = manifest.getAttributeValue("package");

--- a/src/main/java/org/aerogear/plugin/intellij/mobile/services/configuration/AndroidManifest.java
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/services/configuration/AndroidManifest.java
@@ -1,0 +1,21 @@
+package org.aerogear.plugin.intellij.mobile.services.configuration;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.xml.XmlTag;
+
+import java.io.File;
+
+public class AndroidManifest extends ConfigurationXml{
+
+    public AndroidManifest() {}
+
+    public String getPackage(Project project) {
+        String packageName = "";
+        XmlTag manifest = this.getRootTag(project,project.getBasePath() + File.separator + "AndroidManifest.xml");
+        if (manifest != null) {
+            packageName = manifest.getAttributeValue("package");
+        }
+
+        return packageName;
+    }
+}

--- a/src/main/java/org/aerogear/plugin/intellij/mobile/services/configuration/AndroidManifest.java
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/services/configuration/AndroidManifest.java
@@ -11,7 +11,8 @@ public class AndroidManifest extends ConfigurationXml{
 
     public String getPackage(Project project) {
         String packageName = "";
-        XmlTag manifest = this.getRootTag(project,project.getBasePath() + File.separator + "AndroidManifest.xml");
+        String manifestPath = project.getBasePath() + File.separator + "src" + File.separator + "main" + File.separator + "AndroidManifest.xml";
+        XmlTag manifest = this.getRootTag(project, manifestPath);
         if (manifest != null) {
             packageName = manifest.getAttributeValue("package");
         }

--- a/src/main/java/org/aerogear/plugin/intellij/mobile/services/configuration/ConfigurationXml.java
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/services/configuration/ConfigurationXml.java
@@ -14,11 +14,8 @@ public abstract class ConfigurationXml {
 
     protected XmlTag getRootTag(Project project, String path) {
         XmlTag rootTag = null;
-        VirtualFile vFile = ApplicationManager.getApplication().runReadAction(new Computable<VirtualFile>() {
-            @Override
-            public VirtualFile compute() {
-                return LocalFileSystem.getInstance().refreshAndFindFileByPath(path);
-            }
+        VirtualFile vFile = ApplicationManager.getApplication().runReadAction((Computable<VirtualFile>) () -> {
+            return LocalFileSystem.getInstance().refreshAndFindFileByPath(path);
         });
 
         if (vFile != null) {

--- a/src/main/java/org/aerogear/plugin/intellij/mobile/services/configuration/ConfigurationXml.java
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/services/configuration/ConfigurationXml.java
@@ -1,0 +1,34 @@
+package org.aerogear.plugin.intellij.mobile.services.configuration;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Computable;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.xml.XmlDocument;
+import com.intellij.psi.xml.XmlFile;
+import com.intellij.psi.xml.XmlTag;
+
+public abstract class ConfigurationXml {
+
+    protected XmlTag getRootTag(Project project, String path) {
+        XmlTag rootTag = null;
+        VirtualFile vFile = ApplicationManager.getApplication().runReadAction(new Computable<VirtualFile>() {
+            @Override
+            public VirtualFile compute() {
+                return LocalFileSystem.getInstance().refreshAndFindFileByPath(path);
+            }
+        });
+
+        if (vFile != null) {
+            final XmlFile xmlFile = (XmlFile) PsiManager.getInstance(project).findFile(vFile);
+            final XmlDocument document = xmlFile.getDocument();
+            if (document != null) {
+                rootTag = document.getRootTag();
+            }
+        }
+
+        return rootTag;
+    }
+}

--- a/src/main/java/org/aerogear/plugin/intellij/mobile/services/configuration/CordovaConfig.java
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/services/configuration/CordovaConfig.java
@@ -4,21 +4,22 @@ import com.intellij.openapi.project.Project;
 import com.intellij.psi.xml.XmlTag;
 
 import java.io.File;
+import java.util.ArrayList;
 
-public class CordovaConfig extends ConfigurationXml{
+public class CordovaConfig extends ConfigurationXml {
 
     public CordovaConfig() {}
 
     public String getId(Project project) {
-        String id = "";
-        String basePath = project.getBasePath() + File.separator + "app" + File.separator;
-        XmlTag widget = this.getRootTag(project,basePath + "config.xml");
-        if (widget != null) {
-            id = widget.getAttributeValue("id");
-        }
+        ArrayList<String> possiblePaths = new ArrayList<>();
+        String basePath = project.getBasePath();
+        possiblePaths.add(basePath + File.separator + "config.xml");
+        possiblePaths.add(basePath + File.separator + "app" + File.separator + "config.xml");
+        possiblePaths.add(basePath + File.separator + "app" + File.separator + "www" + File.separator + "config.xml");
 
-        if (id.isEmpty()) {
-            widget = this.getRootTag(project,basePath + "www" + File.separator +"config.xml");
+        String id = "";
+        for(int i = 0; i < possiblePaths.size() && id.isEmpty(); i++) {
+            XmlTag widget = this.getRootTag(project, possiblePaths.get(i));
             if (widget != null) {
                 id = widget.getAttributeValue("id");
             }

--- a/src/main/java/org/aerogear/plugin/intellij/mobile/services/configuration/CordovaConfig.java
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/services/configuration/CordovaConfig.java
@@ -1,0 +1,29 @@
+package org.aerogear.plugin.intellij.mobile.services.configuration;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.xml.XmlTag;
+
+import java.io.File;
+
+public class CordovaConfig extends ConfigurationXml{
+
+    public CordovaConfig() {}
+
+    public String getId(Project project) {
+        String id = "";
+        String basePath = project.getBasePath() + File.separator + "app" + File.separator;
+        XmlTag widget = this.getRootTag(project,basePath + "config.xml");
+        if (widget != null) {
+            id = widget.getAttributeValue("id");
+        }
+
+        if (id.isEmpty()) {
+            widget = this.getRootTag(project,basePath + "www" + File.separator +"config.xml");
+            if (widget != null) {
+                id = widget.getAttributeValue("id");
+            }
+        }
+
+        return id;
+    }
+}

--- a/src/main/java/org/aerogear/plugin/intellij/mobile/services/configuration/ProjectConfiguration.java
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/services/configuration/ProjectConfiguration.java
@@ -1,0 +1,22 @@
+package org.aerogear.plugin.intellij.mobile.services.configuration;
+
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.project.Project;
+
+public class ProjectConfiguration {
+
+    public ProjectConfiguration() {}
+
+    public String getAppId(Project project) {
+        String appId = new AndroidManifest().getPackage(project);
+        if (appId.isEmpty()) {
+            appId = new CordovaConfig().getId(project);
+        }
+
+        return appId;
+    }
+
+    public static ProjectConfiguration getInstance(Project project) {
+        return ServiceManager.getService(project, ProjectConfiguration.class);
+    }
+}

--- a/src/main/java/org/aerogear/plugin/intellij/mobile/ui/actions/ClientCreatedCheck.java
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/ui/actions/ClientCreatedCheck.java
@@ -23,11 +23,8 @@ public class ClientCreatedCheck implements StartupActivity {
     }
 
     private void checkFile(String filePath, @NotNull Project project) {
-        VirtualFile file = ApplicationManager.getApplication().runReadAction(new Computable<VirtualFile>() {
-            @Override
-            public VirtualFile compute() {
-                return LocalFileSystem.getInstance().refreshAndFindFileByPath(filePath);
-            }
+        VirtualFile file = ApplicationManager.getApplication().runReadAction((Computable<VirtualFile>) () -> {
+            return LocalFileSystem.getInstance().refreshAndFindFileByPath(filePath);
         });
 
         if (file == null) {

--- a/src/main/java/org/aerogear/plugin/intellij/mobile/ui/actions/ClientCreatedCheck.java
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/ui/actions/ClientCreatedCheck.java
@@ -1,13 +1,16 @@
 package org.aerogear.plugin.intellij.mobile.ui.actions;
 
 import com.intellij.notification.NotificationListener;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
+import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.aerogear.plugin.intellij.mobile.api.CLIRunnerImpl;
 import org.aerogear.plugin.intellij.mobile.api.MobileAPI;
 import org.aerogear.plugin.intellij.mobile.services.MobileNotificationsService;
+import org.aerogear.plugin.intellij.mobile.services.configuration.ProjectConfiguration;
 import org.aerogear.plugin.intellij.mobile.ui.MobileIcons;
 import org.jetbrains.annotations.NotNull;
 
@@ -20,12 +23,20 @@ public class ClientCreatedCheck implements StartupActivity {
     }
 
     private void checkFile(String filePath, @NotNull Project project) {
-        VirtualFile file = LocalFileSystem.getInstance().refreshAndFindFileByPath(filePath);
+        VirtualFile file = ApplicationManager.getApplication().runReadAction(new Computable<VirtualFile>() {
+            @Override
+            public VirtualFile compute() {
+                return LocalFileSystem.getInstance().refreshAndFindFileByPath(filePath);
+            }
+        });
 
         if (file == null) {
             MobileAPI mobileAPI = new MobileAPI(CLIRunnerImpl.getInstance());
 
-            NotificationListener notificationListener = (notification, event) -> new ClientCreatedCheckAction().showCreateClientForm(project, mobileAPI, filePath);
+            NotificationListener notificationListener = (notification, event) -> {
+                String appId = ProjectConfiguration.getInstance(project).getAppId(project);
+                new ClientCreatedCheckAction().showCreateClientForm(project, mobileAPI, filePath, appId);
+            };
 
             new MobileNotificationsService().notifyWarning(
                     MobileIcons.AEROGEAR,

--- a/src/main/java/org/aerogear/plugin/intellij/mobile/ui/actions/ClientCreatedCheckAction.java
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/ui/actions/ClientCreatedCheckAction.java
@@ -31,7 +31,7 @@ public class ClientCreatedCheckAction extends AnAction {
     String filePath = project.getBasePath() + File.separator + Constants.DOT_FILENAME;
 
     String appId = ProjectConfiguration.getInstance(project).getAppId(project);
-    showCreateClientForm(e.getProject(), mobileAPI, filePath, appId);
+    showCreateClientForm(project, mobileAPI, filePath, appId);
   }
 
   public void showCreateClientForm(Project project, MobileAPI mobileAPI, String filePath, String appId) {

--- a/src/main/java/org/aerogear/plugin/intellij/mobile/ui/actions/ClientCreatedCheckAction.java
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/ui/actions/ClientCreatedCheckAction.java
@@ -10,9 +10,11 @@ import org.aerogear.plugin.intellij.mobile.api.MobileAPI;
 import org.aerogear.plugin.intellij.mobile.models.MobileClient;
 import org.aerogear.plugin.intellij.mobile.services.AeroGearMobileConfiguration;
 import org.aerogear.plugin.intellij.mobile.services.MobileNotificationsService;
+import org.aerogear.plugin.intellij.mobile.services.configuration.ProjectConfiguration;
 import org.aerogear.plugin.intellij.mobile.ui.createclientpopup.CreateClientForm;
 import org.aerogear.plugin.intellij.mobile.utils.WriteToFileRunnable;
 
+import java.io.File;
 import java.util.Objects;
 
 public class ClientCreatedCheckAction extends AnAction {
@@ -25,12 +27,15 @@ public class ClientCreatedCheckAction extends AnAction {
   @Override
   public void actionPerformed(AnActionEvent e) {
     MobileAPI mobileAPI = new MobileAPI(CLIRunnerImpl.getInstance());
-    String filePath = Objects.requireNonNull(e.getProject()).getBasePath() + "/" + Constants.DOT_FILENAME;
-    showCreateClientForm(e.getProject(), mobileAPI, filePath);
+    Project project = Objects.requireNonNull(e.getProject());
+    String filePath = project.getBasePath() + File.separator + Constants.DOT_FILENAME;
+
+    String appId = ProjectConfiguration.getInstance(project).getAppId(project);
+    showCreateClientForm(e.getProject(), mobileAPI, filePath, appId);
   }
 
-  public void showCreateClientForm(Project project, MobileAPI mobileAPI, String filePath) {
-    CreateClientForm clientForm = new CreateClientForm(project, mobileAPI);
+  public void showCreateClientForm(Project project, MobileAPI mobileAPI, String filePath, String appId) {
+    CreateClientForm clientForm = new CreateClientForm(project, mobileAPI, appId);
     clientForm.show();
 
     if (CreateClientForm.OK_EXIT_CODE == clientForm.getExitCode()) {

--- a/src/main/java/org/aerogear/plugin/intellij/mobile/ui/createclientpopup/CreateClientForm.java
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/ui/createclientpopup/CreateClientForm.java
@@ -31,10 +31,12 @@ public class CreateClientForm extends DialogWrapper {
   private Border defaultClientNameBorder;
   private CreateClientFormInputs formInputs;
   private final MobileAPI mobileAPI;
+  private String appId;
 
-  public CreateClientForm(@Nullable Project project, MobileAPI mobileAPI) {
+  public CreateClientForm(@Nullable Project project, MobileAPI mobileAPI, String appId) {
     super(project);
     this.mobileAPI = mobileAPI;
+    this.appId = appId;
     init();
     setTitle(Constants.CREATE_CLIENT);
   }
@@ -81,6 +83,7 @@ public class CreateClientForm extends DialogWrapper {
   @Nullable
   @Override
   protected JComponent createCenterPanel() {
+    clientAppIdTxtField.setText(this.appId);
     return clientPanel;
   }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -32,6 +32,7 @@
         <projectConfigurable groupId="tools" displayName="AeroGear Mobile" id="aerogear.mobile.configurable" instance="org.aerogear.plugin.intellij.mobile.ui.settings.AeroGearMobileConfigurable" />
         <projectService serviceImplementation="org.aerogear.plugin.intellij.mobile.services.AeroGearMobileConfiguration"/>
         <projectService serviceImplementation="org.aerogear.plugin.intellij.mobile.services.sdkconfig.SDKConfigManager"/>
+        <projectService serviceImplementation="org.aerogear.plugin.intellij.mobile.services.configuration.ProjectConfiguration"/>
         <!-- HOOKS -->
         <postStartupActivity implementation="org.aerogear.plugin.intellij.mobile.ui.actions.ClientCreatedCheck"/>
     </extensions>


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Pre-fill packageName on create client pop up in intelij plugin. This will be used as the appId in the client resource

**Changes proposed in this pull request**
 - new `ProjectConfigurationService` to retrieve the info. Retrieved from the `AndroidManifest.xml` for Android and the `config.xml` for cordova.
`Androidmanifest` is in the project root folder while the cordova config can be in `app/config.xml` or `app/www/config.xml`

fixes https://issues.jboss.org/browse/AEROGEAR-2038

Android studio:
![packagename](https://user-images.githubusercontent.com/22113654/36321956-8e9a5014-1343-11e8-8fa5-c18b2c316896.png)
WebStorm:
![id](https://user-images.githubusercontent.com/22113654/36321960-91cd57a4-1343-11e8-8c3d-87db2d03e717.png)
