### PR TITLE
AEROGEAR-2162 Update methods to specify the namespace

### DIFF
--- a/src/main/java/org/aerogear/plugin/intellij/mobile/api/MobileAPI.java
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/api/MobileAPI.java
@@ -19,8 +19,8 @@ public class MobileAPI {
         this.cliRunner = cliRunner;
     }
 
-    public MobileServices getServices() throws CLIException {
-        String outPut = cliRunner.executeSync(Arrays.asList("get", "services", "--", "-o=json"));
+    public MobileServices getServices(String namespace) throws CLIException {
+        String outPut = cliRunner.executeSync(Arrays.asList("get", "services", "--namespace=" + namespace, "--", "-o=json"));
         Gson gson = new Gson();
         try {
             return gson.fromJson(outPut, MobileServices.class);
@@ -29,8 +29,8 @@ public class MobileAPI {
         }
     }
 
-    public void createService(ServiceClass sc, List<String> params, Watcher w) {
-        List<String> cmd = new ArrayList<>(Arrays.asList("create","serviceinstance",sc.getServiceName(),"--"));
+    public void createService(ServiceClass sc, List<String> params, String namespace, Watcher w) {
+        List<String> cmd = new ArrayList<>(Arrays.asList("create", "serviceinstance", sc.getServiceName(), "--namespace=" + namespace, "--"));
         for (String param : params) {
             cmd.add("-p");
             cmd.add(param);
@@ -38,20 +38,20 @@ public class MobileAPI {
         cliRunner.executeAsync(cmd, w);
     }
 
-    public MobileClient createClient(String name, String clientType, String bundleID) throws CLIException {
+    public MobileClient createClient(String name, String clientType, String bundleID, String namespace) throws CLIException {
         if (name.isEmpty() || clientType.isEmpty() || bundleID.isEmpty()) {
             throw new CLIException("Expected a client name, a client type and a bundle id");
         }
-        String res = cliRunner.executeSync(Arrays.asList("create", "client", "--", name, clientType, bundleID, "-o=json"));
+        String res = cliRunner.executeSync(Arrays.asList("create", "client", "--namespace=" + namespace, "--", name, clientType, bundleID, "-o=json"));
 
         return getMobileClientFromRes(res);
     }
 
-    public MobileClient getClient(String name) throws CLIException {
-        if (name.isEmpty()) {
-            throw new CLIException("Expected a client name");
+    public MobileClient getClient(String clientId, String namespace) throws CLIException {
+        if (clientId.isEmpty()) {
+            throw new CLIException("Expected a client ID");
         }
-        String res = cliRunner.executeSync(Arrays.asList("get", "client", "--", name, "-o=json"));
+        String res = cliRunner.executeSync(Arrays.asList("get", "client", "--namespace=" + namespace, "--", clientId, "-o=json"));
         return getMobileClientFromRes(res);
     }
 
@@ -64,9 +64,9 @@ public class MobileAPI {
         }
     }
 
-    public String getClientConfig(String clientName) throws CLIException {
+    public String getClientConfig(String clientId, String namespace) throws CLIException {
         return cliRunner.executeSync(
-            Arrays.asList("get", "clientconfig", "--", clientName, "-o=json")
+                Arrays.asList("get", "clientconfig", "--namespace=" + namespace, "--", clientId, "-o=json")
         );
     }
 }

--- a/src/main/java/org/aerogear/plugin/intellij/mobile/services/sdkconfig/SDKConfigManager.java
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/services/sdkconfig/SDKConfigManager.java
@@ -52,7 +52,7 @@ public class SDKConfigManager {
 
     private CharSequence getClientConfig(Project project) throws CLIException {
         String clientName = this.getClientName(project);
-        return new MobileAPI(CLIRunnerImpl.getInstance()).getClientConfig(clientName);
+        return new MobileAPI(CLIRunnerImpl.getInstance()).getClientConfig(clientName, "namespace");
     }
 
     public static SDKConfigManager getInstance(Project project) {

--- a/src/main/java/org/aerogear/plugin/intellij/mobile/ui/MobileToolWindowFactory.java
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/ui/MobileToolWindowFactory.java
@@ -33,7 +33,7 @@ public class MobileToolWindowFactory implements ToolWindowFactory {
 
         MobileServices serviceList;
         try {
-            serviceList = new MobileAPI(cliRunner).getServices();
+            serviceList = new MobileAPI(cliRunner).getServices("myproject");
             if (serviceList.getItems() != null) {
                 mobileToolWindowContent.add(new ServiceListPane(project, serviceList.getItems()));
             } else {

--- a/src/main/java/org/aerogear/plugin/intellij/mobile/ui/actions/ClientCreatedCheck.java
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/ui/actions/ClientCreatedCheck.java
@@ -90,7 +90,7 @@ public class ClientCreatedCheck implements StartupActivity {
      */
     private Boolean clientExists(String clientId) {
         try {
-            mobileAPI.getClient(clientId);
+            mobileAPI.getClient(clientId, "myproject");
         } catch (CLIException e) {
             return false;
         }

--- a/src/main/java/org/aerogear/plugin/intellij/mobile/ui/actions/ClientCreatedCheckAction.java
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/ui/actions/ClientCreatedCheckAction.java
@@ -36,7 +36,7 @@ public class ClientCreatedCheckAction extends AnAction {
     clientForm.show();
 
     if (CreateClientForm.OK_EXIT_CODE == clientForm.getExitCode()) {
-      MobileClient mobileClient = mobileAPI.createClient(clientForm.getName(), clientForm.getClientType(), clientForm.getAppId());
+      MobileClient mobileClient = mobileAPI.createClient(clientForm.getName(), clientForm.getClientType(), clientForm.getAppId(), "myproject");
       Objects.requireNonNull(AeroGearMobileConfiguration.getInstance(project)).setClientName(mobileClient.getSpec().getName() + "-" + mobileClient.getSpec().getClientType());
 
       CharSequence charSeq = mobileClient.getSpec().toJsonPrettyPrint();

--- a/src/main/java/org/aerogear/plugin/intellij/mobile/ui/actions/ViewClientConfig.java
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/ui/actions/ViewClientConfig.java
@@ -20,7 +20,7 @@ public class ViewClientConfig extends AnAction {
         try {
             String clientName = Objects.requireNonNull(AeroGearMobileConfiguration.getInstance(e.getProject())).getClientName();
             if (clientName != null) {
-                String clientSdkConfig = new MobileAPI(CLIRunnerImpl.getInstance()).getClientConfig(clientName);
+                String clientSdkConfig = new MobileAPI(CLIRunnerImpl.getInstance()).getClientConfig(clientName, "myproject");
                 new ViewSDKConfigDialog(clientSdkConfig).show();
             } else {
                 mobileNotificationsService.notifyError("Error from mobile plugin", "Cannot get config: no mobile client exists");

--- a/src/main/java/org/aerogear/plugin/intellij/mobile/ui/createclientpopup/CreateClientForm.java
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/ui/createclientpopup/CreateClientForm.java
@@ -71,7 +71,7 @@ public class CreateClientForm extends DialogWrapper {
     String clientId = (formInputs.getName() + "-" + formInputs.getClientType()).toLowerCase();
 
     try {
-      MobileClient mobileClient = this.mobileAPI.getClient(clientId);
+      MobileClient mobileClient = this.mobileAPI.getClient(clientId, "myproject");
       return new ValidationInfo(String.format("Client name and type duplicate: %s", mobileClient.spec.name));
     } catch (CLIException e) {
       // this is fine https://i.imgur.com/mtGc7Sl.gif

--- a/src/main/java/org/aerogear/plugin/intellij/mobile/ui/servicecatalog/DeployServiceDialog.java
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/ui/servicecatalog/DeployServiceDialog.java
@@ -64,7 +64,7 @@ class DeployServiceDialog extends DialogWrapper {
         List<String> params = this.centerPanel.getConfig();
         Project project = this.project;
         ServiceClass sc = this.sc;
-        ApplicationManager.getApplication().invokeLater(() -> mobileAPI.createService(sc, params, new Watcher() {
+        ApplicationManager.getApplication().invokeLater(() -> mobileAPI.createService(sc, params, "myproject", new Watcher() {
             @Override
             public void onError(Exception e) {
                 notifier.notifyError("", "Error while " + sc.getServiceName() + " deployed: " + e.toString());

--- a/src/test/java/MobileAPITest.java
+++ b/src/test/java/MobileAPITest.java
@@ -50,7 +50,7 @@ public class MobileAPITest {
         + "      }\n"
         + "    }]}");
     MobileAPI api = new MobileAPI(runner);
-    MobileServices services = api.getServices();
+    MobileServices services = api.getServices("myproject");
     Assert.assertNotNull(services);
     if(services.getItems().length == 0){
       Assert.fail("expected service items but got none");
@@ -64,7 +64,7 @@ public class MobileAPITest {
     CLIRunner runner = mock(CLIRunner.class);
     when(runner.executeSync(anyList())).thenThrow(new CLIException("failed to execute command"));
     MobileAPI api = new MobileAPI(runner);
-    api.getServices();
+    api.getServices("myproject");
   }
   
   @Test (expectedExceptions = CLIException.class)
@@ -73,7 +73,7 @@ public class MobileAPITest {
     when(runner.executeSync(anyList())).thenReturn("Error: failed to list service classes: User \"system:anonymous\" cannot list clusterserviceclasses.servicecatalog.k8s.io at the cluster scope: User \"system:anonymous\" cannot list all clusterserviceclasses.servicecatalog.k8s.io in the cluster (get clusterserviceclasses.servicecatalog.k8s.io)\n"
         + "error: exit status 1");
     MobileAPI api = new MobileAPI(runner);
-    api.getServices();
+    api.getServices("myproject");
   }
   
   
@@ -102,7 +102,7 @@ public class MobileAPITest {
         + "\t\t\"appIdentifier\": \"com.my.company\"\n"
         + "\t}\n"
         + "}");
-    MobileClient client = api.createClient("mine","iOS","com.my.company");
+    MobileClient client = api.createClient("mine","iOS","com.my.company", "myproject");
     Assert.assertNotNull(client);
     Assert.assertNotNull(client.spec);
     Assert.assertEquals(client.spec.name,"mine");
@@ -116,7 +116,7 @@ public class MobileAPITest {
   public void testCreateClient_fails_validation_bundleID()throws CLIException{
     CLIRunner runner = mock(CLIRunner.class);
     MobileAPI api = new MobileAPI(runner);
-    api.createClient("mine","android","");
+    api.createClient("mine","android","", "myproject");
   }
   
   


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Specify the namespace as part of every command to avoid accidentally performing an action against the wrong namespace.

**Changes proposed in this pull request**:
 - Update MobileAPI methods to accept a `namespace` parameter
 - Hardcoded all namespaces to `myproject` (to be properly addressed in [AEROGEAR-2163](https://issues.jboss.org/browse/AEROGEAR-2163))