### PR TITLE
config error fix

### DIFF
--- a/src/main/java/org/aerogear/plugin/intellij/mobile/services/configuration/ProjectConfiguration.java
+++ b/src/main/java/org/aerogear/plugin/intellij/mobile/services/configuration/ProjectConfiguration.java
@@ -15,10 +15,11 @@ public class ProjectConfiguration {
         if (appId == null) {
             appId = new CordovaConfig().getBundleId(project);
         }
-
-        return Objects.requireNonNull(
-                         appId,
-                "Unable to find Application ID, AndroidManifest.xml and Cordova config.xml appear to be missing");
+        // not supported project, preffil with empty string rather than crash
+        if (appId == null){
+            appId = ""; 
+        }
+        return appId;
     }
 
     public static ProjectConfiguration getInstance(Project project) {


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
when user opens unsupported project type, the plugin crashed IDE.
This change prefills forms with empty data when appId is not found
